### PR TITLE
If var is used in ResourceInstanceName replace it

### DIFF
--- a/DSCToXTA.psm1
+++ b/DSCToXTA.psm1
@@ -209,8 +209,16 @@ function ConvertFrom-DSCToXTA
         $mappedNamespace = $mappings.($resource.ResourceName)
         if (-not [System.String]::IsNullOrEmpty($mappedNamespace))
         {
+            $ResourceInstanceName = $resource.ResourceInstanceName
+            foreach ($Variable in $Variables) {
+                if ($ResourceInstanceName -like "*$Variable*") {
+                    $ResourceInstanceName  = Format-XTAProperty `
+                        -Property $ResourceInstanceName -Variables $Variable
+                    break
+                }
+            }
             $currentResource = @{
-                displayname = $resource.ResourceInstanceName
+                displayname = $ResourceInstanceName
                 resourceType = $mappedNamespace
             }
 


### PR DESCRIPTION
If one of the variables is used in property ResourceInstanceName of the resource being processed then replace it with concat and parameters as already it's being done done for other properties